### PR TITLE
画面遷移図に沿って画面の導線を調整 + 全体的な見た目を調整

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -11,10 +11,10 @@ class AgendasController < ApplicationController
   end
 
   def create
-    @agenda = current_user.agendas.build(agenda_params)
-    @agenda.team_id = params[:team_id]
+    @agenda = current_user.agendas.build(title: params[:title])
+    @agenda.team = Team.friendly.find(params[:team_id])
     if @agenda.save
-      redirect_to team_agendas_url(@agenda), notice: 'Agenda was successfully created.'
+      redirect_to dashboard_url, notice: 'Agenda was successfully created.'
     else
       render :new
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,10 @@
 class ApplicationController < ActionController::Base
-  before_action :set_team, if: :user_signed_in?
+  before_action :set_working_team, if: :user_signed_in?
 
   private
 
   # FIXME: 暫定的にteamに値を入れる処理をかませる
-  def set_team
-    @team = current_user.teams.first
+  def set_working_team
+    @working_team = current_user.teams.first
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :set_team, if: :user_signed_in?
+
+  private
+
+  # FIXME: 暫定的にteamに値を入れる処理をかませる
+  def set_team
+    @team = current_user.teams.first
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -11,7 +11,7 @@ class ArticlesController < ApplicationController
 
   def new
     @agenda = Agenda.find(params[:agenda_id])
-    @team = Team.find(params[:agenda_id])
+    @team = @agenda.team
     @article = @agenda.articles.build
   end
 

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -2,10 +2,15 @@ class AssignsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    team = Team.find(params[:team_id])
+    team = Team.friendly.find(params[:team_id])
     user = User.find_or_create_by_email(assign_params)
     team.invite_member(user)
     redirect_to team_url(team), notice: 'Completed assign!'
+  end
+
+  def destroy
+    @assign = Assign.find(params[:id])
+    redirect_to team_url(params[:team_id]), notice: 'メンバーを削除しました。'
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -37,6 +37,10 @@ class TeamsController < ApplicationController
     redirect_to teams_url, notice: 'Team was successfully destroyed.'
   end
 
+  def dashboard
+    @team = current_user.teams.first
+  end
+
   private
 
   def set_team

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,7 +3,7 @@ class Users::SessionsController < Devise::SessionsController
 
   private
 
-  def after_sign_in_path_for(resource)
-    team_url(resource.teams.first)
+  def after_sign_in_path_for(_resource)
+    dashboard_url
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Users::SessionsController < Devise::SessionsController
+  layout 'login/application'
+
   private
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,25 +1,7 @@
 class Users::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+  private
 
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
+  def after_sign_in_path_for(resource)
+    team_url(resource.teams.first)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = current_user
+  end
+end

--- a/app/frontend/stylesheets/application.scss
+++ b/app/frontend/stylesheets/application.scss
@@ -2,3 +2,8 @@
 @import 'admin-lte/dist/css/adminlte.min.css';
 $fa-font-path: '~font-awesome/fonts';
 @import '~font-awesome/scss/font-awesome.scss';
+
+.img {
+  width: 100%;
+  height: auto;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,9 @@ module ApplicationHelper
     markdown = Redcarpet::Markdown.new(html_render, options)
     markdown.render(text)
   end
+
+  # FIXME: dashboardに戻るURLは要検討
+  def back_to_dashboard_url
+    team_url(current_user.teams.first) if user_signed_in?
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,9 +15,4 @@ module ApplicationHelper
     markdown = Redcarpet::Markdown.new(html_render, options)
     markdown.render(text)
   end
-
-  # FIXME: dashboardに戻るURLは要検討
-  def back_to_dashboard_url
-    team_url(current_user.teams.first) if user_signed_in?
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,12 @@ module ApplicationHelper
     markdown = Redcarpet::Markdown.new(html_render, options)
     markdown.render(text)
   end
+
+  def select_posting_article_path(article)
+    if article.new_record?
+      agenda_articles_path(article.agenda, article)
+    else
+      article_path(article)
+    end
+  end
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,17 +1,36 @@
-<%= form_with(model: article, local: true) do |form| %>
+<%= form_with(model: article, url: select_posting_article_path(article), local: true) do |form| %>
   <% if article.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(article.errors.count, "error") %> prohibited this article from being saved:</h2>
-
+    <div class="alert alert-danger alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+      <h5>
+        <i class="icon fa fa-ban"></i>
+        <%= pluralize(article.errors.count, "error") %> prohibited this team from being saved:
+      </h5>
       <ul>
         <% article.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+          <li><%= message %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-group">
+    <%= form.label :title %>
+    <%= form.text_field :title, placeholder: '記事タイトルを入力してください', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :content %>
+    <%= form.text_area :content, placeholder: '内容を入力してください', class: 'form-control', rows: 10 %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :image %><br>
+    <%= form.file_field :image %>
+    <%= form.hidden_field :image_cache %>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit '投稿', class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,6 +1,18 @@
-<h1>Editing Article</h1>
-
-<%= render 'form', article: @article %>
-
-<%= link_to 'Show', @article %> |
-<%= link_to 'Back', agenda_articles_path(@article.agenda) %>
+<div class="row mt-3">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">
+          記事を編集する
+        </h3>
+      </div>
+      <!-- /.card-header -->
+      <div class="card-body">
+        <%= render 'form', article: @article %>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,31 +1,18 @@
-<h1>New Article</h1>
-
-<%= form_with(model: @article, url: agenda_articles_path(@agenda), local: true) do |form| %>
-  <% if @article.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@article.errors.count, "error") %> prohibited this article from being saved:</h2>
-
-      <ul>
-      <% @article.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
+<div class="row mt-3">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">
+          記事を作成する
+        </h3>
+      </div>
+      <!-- /.card-header -->
+      <div class="card-body">
+        <%= render 'form', article: @article %>
+      </div>
+      <!-- /.card-body -->
     </div>
-  <% end %>
-  <div>
-    <%= form.text_field :title %>
+    <!-- /.card -->
   </div>
-  <div>
-    <%= form.text_area :content %>
-  </div>
-  <div>
-    <%= form.file_field :image %>
-    <%= form.hidden_field :image_cache %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
-
-<%= link_to 'Back', agenda_articles_path(@agenda) %>
+  <!-- ./col -->
+</div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,24 +1,25 @@
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>team.name:</strong>
-  <%= @article.team.name %>
-</p>
-
-<p>
-  <strong>user.email:</strong>
-  <%= @article.user.email %>
-</p>
-
-<p>
-  <strong>title:</strong>
-  <%= @article.title %>
-</p>
-
-<p>
-  <%= markdown(@article.content).html_safe %>
-</p>
-<%#= image_tag @article.image_url %>
-
-<%= link_to 'Edit', edit_article_path(@article) %> |
-<%= link_to 'Back', agenda_articles_path(@article.agenda) %>
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">
+          <%= @article.title %>
+        </h3>
+        <%= @article.user.email %>
+        <%= l(@article.created_at, format: :long) %>
+        <%= link_to '編集', edit_article_path(@article) %>
+        <%= link_to '削除', article_path(@article), method: :delete %>
+      </div>
+      <!-- /.card-header -->
+      <div class="card-body">
+        <%= markdown(@article.content).html_safe %>
+        <%= image_tag @article.image_url if @article.image_url %>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@ scratch. This page gets rid of all links and provides the needed markup only.
       <%= render 'shared/layout/menu' %>
 
       <div class="content-wrapper">
-        <%= yield %>
+        <div class="content">
+          <%= yield %>
+        </div>
       </div>
 
       <%= render 'shared/layout/footer' %>

--- a/app/views/layouts/login/application.html.erb
+++ b/app/views/layouts/login/application.html.erb
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>diveintopost | Log in</title>
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
+  </head>
+
+  <body class="hold-transition login-page">
+    <div class="login-box">
+      <div class="login-logo">
+        DIVE INTO POST
+      </div>
+      <!-- /.login-logo -->
+      <div class="card">
+        <div class="card-body login-card-body">
+          <%= yield %>
+        </div>
+        <!-- /.login-card-body -->
+      </div>
+    </div>
+    <!-- /.login-box -->
+
+    <%= javascript_pack_tag 'application' %>
+  </body>
+</html>

--- a/app/views/shared/layout/_menu.html.erb
+++ b/app/views/shared/layout/_menu.html.erb
@@ -1,9 +1,24 @@
 <aside class="control-sidebar control-sidebar-dark">
   <!-- Control sidebar content goes here -->
   <div class="p-3">
-    <h5>Menu</h5>
     <% if user_signed_in? %>
-      <p><%= link_to 'Logout', destroy_user_session_path, method: :delete %></p>
+      <h5>Menu</h5>
+      <p><%= link_to 'マイページ', '#' %></p>
+      <p><%= link_to 'チーム作成', new_team_path %></p>
+
+      <h5>チーム選択</h5>
+      <% current_user.teams.each do |team| %>
+        <%= link_to team_path(team) do %>
+          <p>
+            <%= image_tag default_img(team.icon_url), size: '30x30' %>&nbsp;
+            <%= team.name %>
+          </p>
+        <% end %>
+      <% end %>
+
+      <p>
+        <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'btn btn-danger btn-block' %>
+      </p>
     <% end %>
   </div>
 </aside>

--- a/app/views/shared/layout/_menu.html.erb
+++ b/app/views/shared/layout/_menu.html.erb
@@ -3,7 +3,7 @@
   <div class="p-3">
     <% if user_signed_in? %>
       <h5>Menu</h5>
-      <p><%= link_to 'マイページ', '#' %></p>
+      <p><%= link_to 'マイページ', user_path %></p>
       <p><%= link_to 'チーム作成', new_team_path %></p>
 
       <h5>チーム選択</h5>

--- a/app/views/shared/layout/_menu.html.erb
+++ b/app/views/shared/layout/_menu.html.erb
@@ -12,6 +12,7 @@
           <p>
             <%= image_tag default_img(team.icon_url), size: '30x30' %>&nbsp;
             <%= team.name %>
+            <%= link_to '管理', team_path(team), class: 'btn btn-info btn-sm float-right' %>
           </p>
         <% end %>
       <% end %>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <aside class="main-sidebar sidebar-dark-primary elevation-4">
   <!-- Brand Logo -->
-  <%= link_to back_to_dashboard_url, class: 'brand-link' do %>
+  <%= link_to dashboard_url, class: 'brand-link' do %>
     <span class="brand-text font-weight-light">DIVE INTO POST</span>
   <% end %>
 

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -6,6 +6,19 @@
 
   <!-- Sidebar -->
   <div class="sidebar">
+    <div class="user-panel mt-3 pb-3 mb-3">
+      <div class="info">
+        <a href="#" class="d-block mb-1">アジェンダ作成</a>
+        <%= form_with model: :agenda, scope: :post, url: team_agendas_path(@team), local: true do |form| %>
+          <div class="input-group input-group-sm">
+            <%= text_field_tag :title, '', { class: 'form-control', placeholder: 'タイトル入力' } %>
+            <span class="input-group-append">
+              <button type="submit" class="btn btn-info btn-flat">作成</button>
+            </span>
+          </div>
+        <% end %>
+      </div>
+    </div>
     <!-- Sidebar Menu -->
     <nav class="mt-2">
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
@@ -26,6 +39,11 @@
                   <% end %>
                 </li>
               <% end %>
+              <li class="nav-item">
+                <%= link_to new_agenda_article_path(agenda), class: 'nav-link' do %>
+                  <p>+ 記事を作成する</p>
+                <% end %>
+              </li>
             </ul>
           </li>
         <% end %>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -9,12 +9,26 @@
     <!-- Sidebar Menu -->
     <nav class="mt-2">
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
-        <li class="nav-item">
-          <a href="#" class="nav-link">
-            <i class="nav-icon fa fa-th"></i>
-            <p>Sample</p>
-          </a>
-        </li>
+        <% @team.agendas.each do |agenda| %>
+          <li class="nav-item has-treeview menu-open">
+            <a href="#" class="nav-link">
+              <i class="fa fa-circle-o nav-icon"></i>
+              <p>
+                <%= agenda.title %>
+                <i class="right fa fa-angle-left"></i>
+              </p>
+            </a>
+            <ul class="nav nav-treeview" style="display: block;">
+              <% agenda.articles.each do |article| %>
+                <li class="nav-item">
+                  <%= link_to article_path(article), class: 'nav-link' do %>
+                    <p><%= article.title %></p>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
       </ul>
     </nav>
     <!-- /.sidebar-menu -->

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -9,7 +9,7 @@
     <div class="user-panel mt-3 pb-3 mb-3">
       <div class="info">
         <a href="#" class="d-block mb-1">アジェンダ作成</a>
-        <%= form_with model: :agenda, scope: :post, url: team_agendas_path(@team), local: true do |form| %>
+        <%= form_with model: :agenda, scope: :post, url: team_agendas_path(@working_team), local: true do |form| %>
           <div class="input-group input-group-sm">
             <%= text_field_tag :title, '', { class: 'form-control', placeholder: 'タイトル入力' } %>
             <span class="input-group-append">
@@ -22,7 +22,7 @@
     <!-- Sidebar Menu -->
     <nav class="mt-2">
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
-        <% @team.agendas.each do |agenda| %>
+        <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
             <a href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -1,8 +1,8 @@
 <aside class="main-sidebar sidebar-dark-primary elevation-4">
   <!-- Brand Logo -->
-  <a href="index3.html" class="brand-link">
+  <%= link_to back_to_dashboard_url, class: 'brand-link' do %>
     <span class="brand-text font-weight-light">DIVE INTO POST</span>
-  </a>
+  <% end %>
 
   <!-- Sidebar -->
   <div class="sidebar">

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -1,25 +1,31 @@
 <%= form_with(model: team, local: true) do |form| %>
   <% if team.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(team.errors.count, "error") %> prohibited this team from being saved:</h2>
-
+    <div class="alert alert-danger alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+      <h5>
+        <i class="icon fa fa-ban"></i>
+        <%= pluralize(team.errors.count, "error") %> prohibited this team from being saved:
+      </h5>
       <ul>
-      <% team.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
+        <% team.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
       </ul>
     </div>
   <% end %>
 
-  <div>
-    <%= form.text_field :name %>
+  <div class="form-group">
+    <%= form.label :name %>
+    <%= form.text_field :name, placeholder: 'チーム名を入力してください', class: 'form-control' %>
   </div>
-  <div>
+
+  <div class="form-group">
+    <%= form.label :icon %><br>
     <%= form.file_field :icon %>
     <%= form.hidden_field :icon_cache %>
   </div>
 
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-group">
+    <%= form.submit '作成', class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/teams/dashboard.html.erb
+++ b/app/views/teams/dashboard.html.erb
@@ -1,0 +1,54 @@
+<div class="row mt-3">
+  <div class="col-md-8">
+    <div class="card">
+      <div class="card-title p-1">
+        最近投稿された記事
+      </div>
+      <div class="card-body p-0">
+        <table class="table">
+          <tbody>
+            <% @team.articles.each do |article| %>
+              <tr>
+                <td><%= image_tag default_img(nil), size: '40x40' %></td>
+                <td>
+                  <%= link_to article_path(article) do %>
+                    <span class="badge bg-primary"><%= article.agenda.title %></span>
+                    <%= article.title %>
+                  <% end %>
+                  <br>
+                  <%= l(article.created_at, format: :long) %>に投稿
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+
+  <div class="col-md-4">
+    <div class="card">
+      <div class="card-title p-1">
+        チームメンバー一覧
+      </div>
+      <div class="card-body p-0">
+        <table class="table">
+          <tbody>
+            <% @team.members.each do |member| %>
+              <tr>
+                <td><%= image_tag default_img(nil), size: '40x40' %></td>
+                <td><%= member.email %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -1,6 +1,18 @@
-<h1>Editing Team</h1>
-
-<%= render 'form', team: @team %>
-
-<%= link_to 'Show', @team %> |
-<%= link_to 'Back', teams_path %>
+<div class="row mt-3">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">
+          チームを編集する
+        </h3>
+      </div>
+      <!-- /.card-header -->
+      <div class="card-body">
+        <%= render 'form', team: @team %>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,5 +1,18 @@
-<h1>New Team</h1>
-
-<%= render 'form', team: @team %>
-
-<%= link_to 'Back', teams_path %>
+<div class="row mt-3">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">
+          チームを作成する
+        </h3>
+      </div>
+      <!-- /.card-header -->
+      <div class="card-body">
+        <%= render 'form', team: @team %>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,35 +1,51 @@
 <p id="notice"><%= notice %></p>
-<%= @team.name %>
 
-<hr>
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body">
+        <div class="row">
+          <div class="col-md-4">
+            <div>
+              <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
+              <%= @team.name %>
+            </div>
+            <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+          </div>
 
-<p><%= image_tag default_img(@team.icon_url) %></p>
-<h2>チームメンバー</h2>
-<ul>
-  <% @team.members.each do |member| %>
-    <li>
-      <%= member.email %>
-    </li>
-  <% end %>
-</ul>
+          <div class="col-md-8">
+            <div>
+              <h5>チームメンバー招待</h5>
+              <%= form_with model: :assign, scope: :post, url: team_assigns_path(@team), local: true do |form| %>
+                <div class="input-group input-group-sm">
+                  <%= text_field_tag :email, '', { class: 'form-control', placeholder: '招待したい人のメールアドレスを入力してください' } %>
+                  <span class="input-group-append">
+                    <button type="submit" class="btn btn-info btn-flat">招待</button>
+                  </span>
+                </div>
+              <% end %>
+            </div>
 
-<hr>
-<h2>メンバー招待</h2>
-<%= form_with model: :assign, scope: :post, url: team_assigns_path(@team), local: true do |form| %>
-  <%= text_field_tag :email %>
-  <%= submit_tag '招待' %>
-<% end %>
-
-<h2>Agendas</h2>
-<ul>
-  <% @team.agendas.each do |agenda| %>
-    <li>
-      <%= agenda.title %>
-    </li>
-  <% end %>
-</ul>
-
-<hr>
-<%= link_to 'Agenda', team_agendas_path(@team) %>
-<%= link_to 'Edit', edit_team_path(@team) %> |
-<%= link_to 'Back', teams_path %>
+            <div class="mt-4">
+              <h5>チームメンバー</h5>
+              <table class="table">
+                <tbody>
+                  <% @team.assigns.each do |assign| %>
+                    <tr>
+                      <td><%= image_tag 'default.jpg', size: '40x40' %></td>
+                      <td><%= assign.user.email %></td>
+                      <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,25 +1,33 @@
-<h2>Log in</h2>
-
+<p class="login-box-msg">Sign in to start your session</p>
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+  <div class="input-group mb-3">
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', placeholder: 'Email' %>
+    <div class="input-group-append">
+      <span class="fa fa-envelope input-group-text"></span>
     </div>
-  <% end -%>
+  </div>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+  <div class="input-group mb-3">
+    <%= f.password_field :password, autocomplete: "off", class: "form-control", placeholder: "Password" %>
+    <div class="input-group-append">
+        <span class="fa fa-lock input-group-text"></span>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <div class="checkbox icheck">
+        <label>
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me %>
+        </label>
+      </div>
+    </div>
+    <!-- /.col -->
+    <div class="col-4">
+      <%= f.submit "Sign In", class: 'btn btn-primary btn-block btn-flat' %>
+    </div>
+    <!-- /.col -->
   </div>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,59 @@
+<p id="notice"><%= notice %></p>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body">
+        <div class="row">
+          <div class="col-md-4">
+            <div>
+              <%= image_tag default_img(nil), class: 'img' %><br>
+              <%= @user.email %>
+            </div>
+            <%= link_to 'プロフィールを編集', '#', class: 'btn btn-success btn-block mt-3' %>
+          </div>
+
+          <div class="col-md-8">
+            <div>
+              <h5>所属しているチーム</h5>
+              <table class="table">
+                <tbody>
+                  <% @user.teams.each do |team| %>
+                    <tr>
+                      <td><%= image_tag default_img(@team.icon_url), size: '40x40' %></td>
+                      <td><%= team.name %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="mt-4">
+              <h5>投稿した記事一覧</h5>
+              <table class="table">
+                <tbody>
+                  <% @user.articles.each do |article| %>
+                    <tr>
+                      <td><%= image_tag default_img(article.team.icon_url), size: '40x40' %></td>
+                      <td>
+                        <%= link_to article_path(article) do %>
+                          <span class="badge bg-primary"><%= article.agenda.title %></span>
+                          <%= article.title %>
+                        <% end %>
+                        <br>
+                        <%= l(article.created_at, format: :long) %>に投稿
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- /.card-body -->
+    </div>
+    <!-- /.card -->
+  </div>
+  <!-- ./col -->
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,11 @@ Rails.application.routes.draw do
   }
 
   resources :teams do
-    resources :assigns, only: %w(create)
+    resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles
     end
   end
+
+  resource :user, only: %w(show)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'statics#top'
+  get :dashboard, to: 'teams#dashboard'
 
   devise_for :users, controllers: {
     sessions: 'users/sessions',

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,11 +2,4 @@ require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
 
-  describe "GET #show" do
-    it "returns http success" do
-      get :show
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end


### PR DESCRIPTION
#31 

## 概要
件名の対応しました。
画面遷移図に従ってダッシュボードをベースにそれぞれの画面に遷移できるように調整しました。
(チーム選択画面は今回のPRでは作成していません)
細かい調整等はしていませんが全体的に見た目を整えました。

## 後から対応が必要
* サイドバーのagendaとarticle表示は無理やり出しているので柔軟に使えるように修正する必要ありです
* アクセス制御を全く行なっていないので制御する必要があります