### PR TITLE
新しいチームが作成されたら、作成者をあらかじめそのチームに入れて保存しておく

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -18,6 +18,7 @@ class TeamsController < ApplicationController
     @team = Team.new(team_params)
     @team.owner = current_user
     if @team.save
+      @team.invite_member(@team.owner)
       redirect_to @team, notice: 'Team was successfully created.'
     else
       render :new


### PR DESCRIPTION
- 済：新しいチームが作成されたら、作成者をあらかじめそのチームに入れて保存しておく

- 未：オーナーは基本退会できないという仕様

- 未：オーナーは他のユーザとは違って目立たせた表示にする（オーナーであることが一目でわかるようにする）

- 未：オーナーはチームメンバーの先頭に置く

- 未：テストも書くよ！