### PR TITLE
【Fixed】Team切り替えの際、左のバーをそのTeamのagendaとarticleを表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   # FIXME: 暫定的にteamに値を入れる処理をかませる。
   # 紐づいているTeamが一件もなかった場合、最初のTeam（BasicTeam（初期チーム））を登録する
   def set_working_team
-    @working_team = current_user.teams.blank? ? Team.first : current_user.teams.first
+    @working_team = Team.first
   end
 
   def init_team

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -6,7 +6,9 @@ class TeamsController < ApplicationController
     @teams = Team.all
   end
 
-  def show; end
+  def show
+    @working_team = @team
+  end
 
   def new
     @team = Team.new


### PR DESCRIPTION
- チームを選択すると、teamのagendaとarticleがでるようになった。

- @working_teamを選択されたチームに。