### PR TITLE
チーム情報の操作に関しての機能を整えること #64

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,4 +429,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   2.0.2

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,7 +30,8 @@ class AssignsController < ApplicationController
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'
-    elsif assign.destroy
+    elsif ( current_user.email == assign.user.email ) || ( current_user == assign.team.owner )
+      assign.destroy
       set_next_team(assign, assigned_user)
       'メンバーを削除しました。'
     else

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -30,7 +30,8 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.update(team_params)
+    if current_user == @team.owner
+      @team.update(team_params)
       redirect_to @team, notice: 'チーム更新に成功しました！'
     else
       flash.now[:error] = '保存に失敗しました、、'

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user == @team.owner %>
+              <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,11 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
+                        <% if ( current_user.email == assign.user.email ) || ( current_user == assign.team.owner ) %>
                       <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% else %>
+                        <td></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
・そのTeamに所属しているUserの削除（離脱）が、どのUserでもできる
・TeamのeditをTeamのリーダー（オーナー）以外でも自由にできる
仕様変更後
・Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにする
・TeamのeditはTeamのリーダー（オーナー）のみができるようにする